### PR TITLE
Correct issues with integration tests and LocalStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.2.0
+
+**Commit Delta**: [Change from 0.1.1 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/0.1.1...0.2.0)
+
+**Released**: 2021.05.03
+
+**Summary**:
+
+*   Revise integration test so it can successfully complete the lambda
+    invocation.
+
 ### 0.1.1
 
 **Commit Delta**: [Change from 0.1.0 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/0.1.0...0.1.1)

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ python/test:
 .PHONY: terraform/pytest
 terraform/pytest: | guard/program/terraform guard/program/pytest
 	@ echo "[$@] Starting test of Terraform lambda installation"
+	@ echo "[$@] LocalStack must be running; 'make localstack/up' can "
+	@ echo "[$@]    be used to start LocalStack"
 	@ echo "[$@] Terraform 'apply' command is slow ... be patient !!!"
 	pytest tests
 	@ echo "[$@]: Completed successfully!"
@@ -31,20 +33,18 @@ terraform/pytest: | guard/program/terraform guard/program/pytest
 .PHONY: localstack/pytest localstack/up localstack/down localstack/clean
 localstack/pytest: | guard/program/terraform guard/program/pytest
 	@ echo "[$@] Running Terraform tests against LocalStack"
-	@ echo "[$@] LocalStack must be running; 'make localstack/up' can "
-	@ echo "[$@]    be used to start LocalStack"
-	DOCKER_RUN_FLAGS="--network host --rm" \
+	DOCKER_RUN_FLAGS="--network tests_default --rm -e LOCALSTACK_HOST=localstack" \
 		TARDIGRADE_CI_DOCKERFILE=Dockerfile_test \
 		IMAGE_NAME=new-account-trust-policy-integration-test:latest \
 		$(MAKE) docker/run target=terraform/pytest
 	@ echo "[$@]: Completed successfully!"
 
 localstack/up: | guard/program/terraform guard/program/pytest
-	@ echo "[$@] Starting LocalStack"
+	@ echo "[$@] Starting LocalStack container"
 	docker-compose -f tests/docker-compose-localstack.yml up --detach
 
 localstack/down: | guard/program/terraform guard/program/pytest
-	@ echo "[$@] Stopping and removing LocalStack container"
+	@ echo "[$@] Stopping LocalStack container"
 	docker-compose -f tests/docker-compose-localstack.yml down
 
 localstack/clean: | localstack/down

--- a/lambda/src/new_account_trust_policy.py
+++ b/lambda/src/new_account_trust_policy.py
@@ -95,6 +95,7 @@ def get_session(assume_role_arn):
         assume_role_arn,
         RoleSessionName=generate_lambda_session_name(function_name),
         DurationSeconds=3600,
+        validate=False,
     )
 
 
@@ -175,6 +176,11 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
         }
     )
     check_for_null_envvars(assume_role_name, update_role_name, trust_policy)
+
+    # If this handler is invoked for an integration test, exit before
+    # invoking any boto3 APIs.
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        return
 
     try:
         account_id = get_account_id(event)

--- a/localstack.tf
+++ b/localstack.tf
@@ -1,1 +1,0 @@
-/workdir/tests/localstack.tf

--- a/localstack.tf
+++ b/localstack.tf
@@ -1,0 +1,1 @@
+/workdir/tests/localstack.tf

--- a/tests/docker-compose-localstack.yml
+++ b/tests/docker-compose-localstack.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
   localstack:
-    container_name: "localstack"
+    container_name: localstack
     image: localstack/localstack
     ports:
       - "4566:4566"

--- a/tests/localstack.tf
+++ b/tests/localstack.tf
@@ -8,12 +8,18 @@ provider "aws" {
   s3_force_path_style         = true
 
   endpoints {
-    cloudwatch       = "http://localhost:4566"
-    cloudwatchevents = "http://localhost:4566"
-    cloudwatchlogs   = "http://localhost:4566"
-    lambda           = "http://localhost:4566"
-    iam              = "http://localhost:4566"
-    sts              = "http://localhost:4566"
-    organizations    = "http://localhost:4615"
+    cloudwatch       = "http://${var.localstack_host}:4566"
+    cloudwatchevents = "http://${var.localstack_host}:4566"
+    cloudwatchlogs   = "http://${var.localstack_host}:4566"
+    lambda           = "http://${var.localstack_host}:4566"
+    iam              = "http://${var.localstack_host}:4566"
+    sts              = "http://${var.localstack_host}:4566"
+    organizations    = "http://${var.localstack_host}:4615"
   }
+}
+
+variable "localstack_host" {
+  description = "Hostname for localstack endpoint"
+  type        = string
+  default     = "localhost"
 }


### PR DESCRIPTION
Prior to this change, the integration test invoked the Lambda knowing that it would fail to execute. However, the failure indicated the Lambda was installed and that was deemed a sufficient integration test for the time being. The Lambda failed because the free version of LocalStack does not support the AWS organizations service so calls to that service were attempting to reach out to AWS itself with erroneous account information.

If all of the boto3 client calls could be modified to specify a LocalStack or moto endpoint_url, then the Lambda could be executed during an integration test. However, there is a call to the botocore library to establish an assumed role and that library call creates a client and we cannot provide arguments for that particular client setup.

So instead of executing the Lambda in its entirety, the handler will only get as far as validating and logging the environment variables before exiting. This is a very simple invocation test, but if writing to the log succeeds, then we know the AWS Powertools library was successfully installed with the Lambda.