### PR TITLE
Bumps version to 0.2.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.2.1
+
+**Commit Delta**: [Change from 0.2.0 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/0.2.0...0.2.1)
+
+**Released**: 2021.05.18
+
+**Summary**:
+
+*   Update aws-assume-role-lib to fix issue where session name exceeded the 64
+    character limit.
+
 ### 0.2.0
 
 **Commit Delta**: [Change from 0.1.1 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/0.1.1...0.2.0)


### PR DESCRIPTION
Updates aws-assume-role-lib to fix issue where session name exceeded the 64 character limit